### PR TITLE
Add creator intelligence features to trend chart

### DIFF
--- a/client/components/ui/trend-chart.tsx
+++ b/client/components/ui/trend-chart.tsx
@@ -43,6 +43,7 @@ export function TrendChart({
   currentTrend,
   peakDate,
   peakListeners,
+  futureOutlook,
 }: TrendChartProps) {
   const combinedData = [...data, ...predictions];
   const currentDate = new Date().toISOString().split("T")[0];

--- a/client/components/ui/trend-chart.tsx
+++ b/client/components/ui/trend-chart.tsx
@@ -294,14 +294,11 @@ export function TrendChart({
           </div>
           <div className="text-center">
             <p className="text-muted-foreground">Creator Signal</p>
-            <p
-              className={`font-semibold text-lg capitalize ${getTrendColor()}`}
-            >
-              {currentTrend === "rising"
-                ? "Use Now"
-                : currentTrend === "declining"
-                  ? "Wait"
-                  : "Safe"}
+            <p className={`font-semibold text-lg ${getCreatorSignal().color}`}>
+              {getCreatorSignal().signal}
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">
+              {getCreatorSignal().reasoning}
             </p>
           </div>
         </div>

--- a/client/components/ui/trend-chart.tsx
+++ b/client/components/ui/trend-chart.tsx
@@ -82,22 +82,61 @@ export function TrendChart({
   };
 
   const getCreatorSignal = () => {
-    // Prioritize future outlook over current trend for creator decisions
-    if (
-      futureOutlook === "explosive_growth" ||
-      futureOutlook === "viral_potential"
-    ) {
-      return {
-        signal: "Use Now!",
-        color: "text-green-600",
-        reasoning: "High viral potential",
-      };
+    // Smart timing logic that considers both current trend and future outlook
+    if (futureOutlook === "explosive_growth") {
+      if (currentTrend === "rising") {
+        return {
+          signal: "Use Now!",
+          color: "text-green-600",
+          reasoning: "Perfect timing",
+        };
+      } else if (currentTrend === "stable") {
+        return {
+          signal: "Use Now",
+          color: "text-green-500",
+          reasoning: "Growth starting",
+        };
+      } else {
+        return {
+          signal: "Wait for Growth",
+          color: "text-orange-500",
+          reasoning: "Growth coming",
+        };
+      }
+    } else if (futureOutlook === "viral_potential") {
+      if (currentTrend === "rising") {
+        return {
+          signal: "Use Now!",
+          color: "text-green-600",
+          reasoning: "Viral momentum",
+        };
+      } else if (currentTrend === "stable") {
+        return {
+          signal: "Use Now",
+          color: "text-green-500",
+          reasoning: "Viral potential",
+        };
+      } else {
+        return {
+          signal: "Monitor",
+          color: "text-orange-500",
+          reasoning: "Potential but declining",
+        };
+      }
     } else if (futureOutlook === "sustained_momentum") {
-      return {
-        signal: "Use Now",
-        color: "text-green-500",
-        reasoning: "Steady growth expected",
-      };
+      if (currentTrend === "declining") {
+        return {
+          signal: "Wait & Watch",
+          color: "text-orange-500",
+          reasoning: "Momentum coming",
+        };
+      } else {
+        return {
+          signal: "Use Now",
+          color: "text-green-500",
+          reasoning: "Steady growth",
+        };
+      }
     } else if (futureOutlook === "comeback_likely") {
       return {
         signal: "Wait & Use",
@@ -111,7 +150,6 @@ export function TrendChart({
         reasoning: "Consistent performance",
       };
     } else if (futureOutlook === "steady_decline") {
-      // Even if declining future, check current trend
       if (currentTrend === "rising") {
         return {
           signal: "Use Soon",

--- a/client/components/ui/trend-chart.tsx
+++ b/client/components/ui/trend-chart.tsx
@@ -81,6 +81,75 @@ export function TrendChart({
     }
   };
 
+  const getCreatorSignal = () => {
+    // Prioritize future outlook over current trend for creator decisions
+    if (
+      futureOutlook === "explosive_growth" ||
+      futureOutlook === "viral_potential"
+    ) {
+      return {
+        signal: "Use Now!",
+        color: "text-green-600",
+        reasoning: "High viral potential",
+      };
+    } else if (futureOutlook === "sustained_momentum") {
+      return {
+        signal: "Use Now",
+        color: "text-green-500",
+        reasoning: "Steady growth expected",
+      };
+    } else if (futureOutlook === "comeback_likely") {
+      return {
+        signal: "Wait & Use",
+        color: "text-orange-500",
+        reasoning: "Comeback predicted",
+      };
+    } else if (futureOutlook === "stable_niche") {
+      return {
+        signal: "Safe Choice",
+        color: "text-blue-500",
+        reasoning: "Consistent performance",
+      };
+    } else if (futureOutlook === "steady_decline") {
+      // Even if declining future, check current trend
+      if (currentTrend === "rising") {
+        return {
+          signal: "Use Soon",
+          color: "text-orange-600",
+          reasoning: "Act before decline",
+        };
+      } else {
+        return {
+          signal: "Consider Alt",
+          color: "text-red-500",
+          reasoning: "Declining trend",
+        };
+      }
+    } else {
+      // Fallback to current trend analysis
+      switch (currentTrend) {
+        case "rising":
+          return {
+            signal: "Use Now",
+            color: "text-green-500",
+            reasoning: "Currently trending",
+          };
+        case "declining":
+          return {
+            signal: "Wait",
+            color: "text-red-500",
+            reasoning: "Currently declining",
+          };
+        default:
+          return {
+            signal: "Safe",
+            color: "text-blue-500",
+            reasoning: "Stable choice",
+          };
+      }
+    }
+  };
+
   const CustomTooltip = ({ active, payload, label }: any) => {
     if (active && payload && payload.length) {
       const isHistorical = new Date(label) <= new Date(currentDate);

--- a/client/components/ui/trend-chart.tsx
+++ b/client/components/ui/trend-chart.tsx
@@ -198,29 +198,33 @@ export function TrendChart({
 
         <div className="mt-4 grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
           <div className="text-center">
-            <p className="text-muted-foreground">Current Listeners</p>
+            <p className="text-muted-foreground">Active Audience</p>
             <p className="font-semibold text-lg text-blue-600">
               {formatNumber(data[data.length - 1]?.infected || 0)}
             </p>
           </div>
           <div className="text-center">
-            <p className="text-muted-foreground">Peak Listeners</p>
+            <p className="text-muted-foreground">Viral Peak</p>
             <p className="font-semibold text-lg">
               {formatNumber(peakListeners)}
             </p>
           </div>
           <div className="text-center">
-            <p className="text-muted-foreground">Market Potential</p>
+            <p className="text-muted-foreground">Total Reach</p>
             <p className="font-semibold text-lg text-slate-600">
               {formatNumber(data[0]?.totalPopulation || 0)}
             </p>
           </div>
           <div className="text-center">
-            <p className="text-muted-foreground">Trend Status</p>
+            <p className="text-muted-foreground">Creator Signal</p>
             <p
               className={`font-semibold text-lg capitalize ${getTrendColor()}`}
             >
-              {currentTrend}
+              {currentTrend === "rising"
+                ? "Use Now"
+                : currentTrend === "declining"
+                  ? "Wait"
+                  : "Safe"}
             </p>
           </div>
         </div>

--- a/client/components/ui/trend-chart.tsx
+++ b/client/components/ui/trend-chart.tsx
@@ -105,11 +105,8 @@ export function TrendChart({
               {getTrendIcon()}
             </CardTitle>
             <CardDescription>
-              Music trend analysis using{" "}
-              {modelType === "SIS"
-                ? "Susceptible-Infected-Susceptible"
-                : "Susceptible-Exposed-Infected-Recovered"}{" "}
-              epidemiological model
+              Content creator intelligence: Track audience engagement patterns
+              and predict optimal timing for maximum viral potential
             </CardDescription>
           </div>
           <div className="text-right">

--- a/client/components/ui/trend-chart.tsx
+++ b/client/components/ui/trend-chart.tsx
@@ -27,6 +27,13 @@ interface TrendChartProps {
   currentTrend: "rising" | "declining" | "stable";
   peakDate: string;
   peakListeners: number;
+  futureOutlook:
+    | "viral_potential"
+    | "steady_decline"
+    | "comeback_likely"
+    | "stable_niche"
+    | "explosive_growth"
+    | "sustained_momentum";
 }
 
 export function TrendChart({

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -132,21 +132,21 @@ export default function Index() {
                 className="text-sm py-2 px-4 border-music-purple/30"
               >
                 <BarChart3 className="h-4 w-4 mr-2" />
-                SEIR & SIS Models
+                Content Performance
               </Badge>
               <Badge
                 variant="outline"
                 className="text-sm py-2 px-4 border-music-blue/30"
               >
                 <TrendingUp className="h-4 w-4 mr-2" />
-                Trend Predictions
+                Viral Potential
               </Badge>
               <Badge
                 variant="outline"
                 className="text-sm py-2 px-4 border-music-pink/30"
               >
                 <Users className="h-4 w-4 mr-2" />
-                Viral Analysis
+                Audience Insights
               </Badge>
             </div>
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -187,10 +187,10 @@ export default function Index() {
                   <div className="flex items-center justify-center w-12 h-12 rounded-full bg-music-purple/10 mx-auto mb-4">
                     <Zap className="h-6 w-6 text-music-purple" />
                   </div>
-                  <h3 className="font-semibold mb-2">Mathematical Models</h3>
+                  <h3 className="font-semibold mb-2">Boost Your Content</h3>
                   <p className="text-sm text-muted-foreground">
-                    Advanced SIS and SEIR epidemiological models adapted for
-                    music trend analysis
+                    Choose songs that will maximize your content's reach and
+                    engagement across social platforms
                   </p>
                 </Card>
 
@@ -198,10 +198,10 @@ export default function Index() {
                   <div className="flex items-center justify-center w-12 h-12 rounded-full bg-music-blue/10 mx-auto mb-4">
                     <TrendingUp className="h-6 w-6 text-music-blue" />
                   </div>
-                  <h3 className="font-semibold mb-2">Trend Predictions</h3>
+                  <h3 className="font-semibold mb-2">Viral Timing</h3>
                   <p className="text-sm text-muted-foreground">
-                    Forecast future popularity trends and identify viral
-                    potential
+                    Know when a song will peak to time your content perfectly
+                    for maximum viral potential
                   </p>
                 </Card>
 
@@ -209,9 +209,10 @@ export default function Index() {
                   <div className="flex items-center justify-center w-12 h-12 rounded-full bg-music-pink/10 mx-auto mb-4">
                     <Globe className="h-6 w-6 text-music-pink" />
                   </div>
-                  <h3 className="font-semibold mb-2">Global Insights</h3>
+                  <h3 className="font-semibold mb-2">Creator Intelligence</h3>
                   <p className="text-sm text-muted-foreground">
-                    Understand audience behavior and market penetration patterns
+                    Get data-driven recommendations tailored for TikTok,
+                    Instagram, YouTube, and other platforms
                   </p>
                 </Card>
               </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -280,91 +280,91 @@ export default function Index() {
                     </Button>
                   </div>
 
-                  {/* Analytics Grid */}
+                  {/* Creator Analytics Grid */}
                   <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-                    {/* Current Popularity */}
+                    {/* Content Boost Score */}
                     <div className="bg-white rounded-lg p-4 border border-slate-200">
                       <div className="flex items-center gap-2 mb-2">
                         <TrendingUp className="h-4 w-4 text-slate-600" />
                         <span className="text-sm font-medium text-slate-600">
-                          Current Popularity
+                          Content Boost Score
                         </span>
                       </div>
                       <div className="text-2xl font-bold text-slate-900">
                         {analysisData.track.popularity}%
                       </div>
+                      <div className="text-xs text-slate-500">
+                        Higher = Better for viral content
+                      </div>
                     </div>
 
-                    {/* All-Time Peak */}
+                    {/* Peak Viral Window */}
                     <div className="bg-white rounded-lg p-4 border border-slate-200">
                       <div className="flex items-center gap-2 mb-2">
                         <BarChart3 className="h-4 w-4 text-slate-600" />
                         <span className="text-sm font-medium text-slate-600">
-                          All-Time Peak
+                          Peak Viral Window
                         </span>
                       </div>
-                      <div className="text-2xl font-bold text-slate-900">
-                        {Math.round(
-                          analysisData.insights.peakListeners / 10000,
-                        )}
-                        %
-                      </div>
-                      <div className="text-xs text-slate-500">
+                      <div className="text-lg font-bold text-slate-900">
                         {new Date(
                           analysisData.insights.peakDate,
                         ).toLocaleDateString("en-US", {
                           month: "short",
-                          year: "numeric",
+                          day: "numeric",
                         })}
+                      </div>
+                      <div className="text-xs text-slate-500">
+                        Best time to post content
                       </div>
                     </div>
 
-                    {/* Future Trend */}
+                    {/* Creator Recommendation */}
                     <div className="bg-white rounded-lg p-4 border border-slate-200">
                       <div className="flex items-center gap-2 mb-2">
                         <Globe className="h-4 w-4 text-slate-600" />
                         <span className="text-sm font-medium text-slate-600">
-                          Next Month
+                          Creator Advice
                         </span>
                       </div>
-                      <div className="text-lg font-bold capitalize">
+                      <div className="text-sm font-bold capitalize">
                         {analysisData.insights.currentTrend === "rising" ? (
-                          <span className="text-green-700">Rising</span>
+                          <span className="text-green-700">Use Now!</span>
                         ) : analysisData.insights.currentTrend ===
                           "declining" ? (
-                          <span className="text-red-700">Declining</span>
+                          <span className="text-orange-700">Wait & See</span>
                         ) : (
-                          <span className="text-yellow-700">Stable</span>
+                          <span className="text-blue-700">Safe Choice</span>
                         )}
                       </div>
                       <div className="text-xs text-slate-500">
-                        {Math.floor(Math.random() * 20) + 75}% confidence
+                        {analysisData.insights.currentTrend === "rising"
+                          ? "Trending up - perfect timing"
+                          : analysisData.insights.currentTrend === "declining"
+                            ? "Consider alternatives"
+                            : "Consistent performance"}
                       </div>
                     </div>
 
-                    {/* Genres */}
+                    {/* Platform Match */}
                     <div className="bg-white rounded-lg p-4 border border-slate-200">
                       <div className="flex items-center gap-2 mb-2">
                         <Music className="h-4 w-4 text-slate-600" />
                         <span className="text-sm font-medium text-slate-600">
-                          Genres
+                          Best Platform
                         </span>
                       </div>
-                      <div className="flex flex-wrap gap-1">
-                        {analysisData.track.genre &&
-                        analysisData.track.genre.length > 0 ? (
-                          analysisData.track.genre.slice(0, 2).map((genre) => (
-                            <Badge
-                              key={genre}
-                              variant="outline"
-                              className="text-xs bg-slate-50"
-                            >
-                              {genre}
-                            </Badge>
-                          ))
-                        ) : (
-                          <span className="text-sm text-slate-500">N/A</span>
-                        )}
+                      <div className="text-sm font-bold">
+                        {analysisData.track.genre?.includes("Pop") ||
+                        analysisData.track.genre?.includes("Alternative")
+                          ? "TikTok + Instagram"
+                          : analysisData.track.genre?.includes("Hip-Hop") ||
+                              analysisData.track.genre?.includes("Rap")
+                            ? "TikTok + YouTube"
+                            : "Instagram + YouTube"}
+                      </div>
+                      <div className="text-xs text-slate-500">
+                        Optimal for this genre
                       </div>
                     </div>
                   </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -379,6 +379,7 @@ export default function Index() {
                 currentTrend={analysisData.insights.currentTrend}
                 peakDate={analysisData.insights.peakDate}
                 peakListeners={analysisData.insights.peakListeners}
+                futureOutlook={analysisData.insights.futureOutlook}
               />
 
               {/* Model Parameters and Insights */}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -394,25 +394,32 @@ export default function Index() {
                           Creator Advice
                         </span>
                       </div>
-                      <div className="text-sm font-bold capitalize">
-                        {analysisData.insights.currentTrend === "rising" ? (
-                          <span className="text-green-700">Use Now!</span>
-                        ) : analysisData.insights.currentTrend ===
-                          "declining" ? (
-                          <span className="text-orange-700">Wait & See</span>
-                        ) : (
-                          <span className="text-blue-700">Safe Choice</span>
-                        )}
+                      <div className="text-sm font-bold">
+                        <span
+                          className={
+                            getCreatorAdvice(
+                              analysisData.insights.currentTrend,
+                              analysisData.insights.futureOutlook,
+                            ).color
+                          }
+                        >
+                          {
+                            getCreatorAdvice(
+                              analysisData.insights.currentTrend,
+                              analysisData.insights.futureOutlook,
+                            ).action
+                          }
+                        </span>
                       </div>
                       <div className="text-xs text-slate-500">
-                        {analysisData.insights.currentTrend === "rising"
-                          ? "Trending up - perfect timing"
-                          : analysisData.insights.currentTrend === "declining"
-                            ? "Consider alternatives"
-                            : "Consistent performance"}
+                        {
+                          getCreatorAdvice(
+                            analysisData.insights.currentTrend,
+                            analysisData.insights.futureOutlook,
+                          ).reasoning
+                        }
                       </div>
                     </div>
-
                     {/* Platform Match */}
                     <div className="bg-white rounded-lg p-4 border border-slate-200">
                       <div className="flex items-center gap-2 mb-2">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -32,21 +32,61 @@ export default function Index() {
 
   // Helper function for consistent creator advice across components
   const getCreatorAdvice = (currentTrend: string, futureOutlook: string) => {
-    if (
-      futureOutlook === "explosive_growth" ||
-      futureOutlook === "viral_potential"
-    ) {
-      return {
-        action: "Use Now!",
-        color: "text-green-700",
-        reasoning: "High viral potential ahead",
-      };
+    // For explosive growth and viral potential, consider current trend timing
+    if (futureOutlook === "explosive_growth") {
+      if (currentTrend === "rising") {
+        return {
+          action: "Use Now!",
+          color: "text-green-700",
+          reasoning: "Perfect timing - explosive growth starting",
+        };
+      } else if (currentTrend === "stable") {
+        return {
+          action: "Use Now",
+          color: "text-green-600",
+          reasoning: "Explosive growth predicted",
+        };
+      } else {
+        return {
+          action: "Wait for Growth",
+          color: "text-orange-600",
+          reasoning: "Explosive growth coming - wait for upturn",
+        };
+      }
+    } else if (futureOutlook === "viral_potential") {
+      if (currentTrend === "rising") {
+        return {
+          action: "Use Now!",
+          color: "text-green-700",
+          reasoning: "Trending up with viral potential",
+        };
+      } else if (currentTrend === "stable") {
+        return {
+          action: "Use Now",
+          color: "text-green-600",
+          reasoning: "Viral potential detected",
+        };
+      } else {
+        return {
+          action: "Monitor Closely",
+          color: "text-orange-600",
+          reasoning: "Viral potential but declining now",
+        };
+      }
     } else if (futureOutlook === "sustained_momentum") {
-      return {
-        action: "Use Now",
-        color: "text-green-600",
-        reasoning: "Steady growth expected",
-      };
+      if (currentTrend === "declining") {
+        return {
+          action: "Wait & Watch",
+          color: "text-orange-600",
+          reasoning: "Momentum coming - wait for upturn",
+        };
+      } else {
+        return {
+          action: "Use Now",
+          color: "text-green-600",
+          reasoning: "Steady growth expected",
+        };
+      }
     } else if (futureOutlook === "comeback_likely") {
       return {
         action: "Wait & Use",

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -121,8 +121,9 @@ export default function Index() {
             </div>
 
             <p className="text-xl md:text-2xl text-black mb-8 leading-relaxed">
-              Analyze the past, present, and future of music trends. Discover
-              any song's viral potential using advanced mathematical models.
+              Choose the perfect soundtrack for viral content. Discover which
+              songs will boost your engagement and reach using AI-powered trend
+              analysis.
             </p>
 
             <div className="flex flex-wrap items-center justify-center gap-4 mb-12">

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -411,12 +411,11 @@ export default function Index() {
         <div className="container mx-auto px-4 py-8">
           <div className="text-center text-sm text-muted-foreground">
             <p className="mb-2">
-              TrendWave - Advanced music trend analysis using mathematical
-              epidemiological models
+              TrendWave - AI-powered music intelligence for content creators
             </p>
             <p>
-              Powered by SIS (Susceptible-Infected-Susceptible) and SEIR
-              (Susceptible-Exposed-Infected-Recovered) models
+              Make smarter song choices. Create viral content. Grow your
+              audience.
             </p>
           </div>
         </div>

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -30,6 +30,73 @@ export default function Index() {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [selectedModel, setSelectedModel] = useState<"SIS" | "SEIR">("SIS");
 
+  // Helper function for consistent creator advice across components
+  const getCreatorAdvice = (currentTrend: string, futureOutlook: string) => {
+    if (
+      futureOutlook === "explosive_growth" ||
+      futureOutlook === "viral_potential"
+    ) {
+      return {
+        action: "Use Now!",
+        color: "text-green-700",
+        reasoning: "High viral potential ahead",
+      };
+    } else if (futureOutlook === "sustained_momentum") {
+      return {
+        action: "Use Now",
+        color: "text-green-600",
+        reasoning: "Steady growth expected",
+      };
+    } else if (futureOutlook === "comeback_likely") {
+      return {
+        action: "Wait & Use",
+        color: "text-orange-600",
+        reasoning: "Comeback predicted soon",
+      };
+    } else if (futureOutlook === "stable_niche") {
+      return {
+        action: "Safe Choice",
+        color: "text-blue-700",
+        reasoning: "Consistent performance",
+      };
+    } else if (futureOutlook === "steady_decline") {
+      if (currentTrend === "rising") {
+        return {
+          action: "Use Soon",
+          color: "text-orange-700",
+          reasoning: "Act before decline",
+        };
+      } else {
+        return {
+          action: "Consider Alt",
+          color: "text-red-700",
+          reasoning: "Better options available",
+        };
+      }
+    } else {
+      return {
+        action: "Safe Choice",
+        color: "text-blue-700",
+        reasoning: "Stable option",
+      };
+    }
+  };
+
+  // Helper function to find upcoming peak from predictions
+  const getUpcomingPeak = (predictions: any[]) => {
+    let peakValue = 0;
+    let peakDate = "";
+
+    predictions.forEach((point) => {
+      if (point.infected > peakValue) {
+        peakValue = point.infected;
+        peakDate = point.date;
+      }
+    });
+
+    return { peakDate, peakValue };
+  };
+
   const handleTrackSelect = async (track: MusicTrack) => {
     setSelectedTrack(track);
     setIsAnalyzing(true);

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -374,15 +374,20 @@ export default function Index() {
                         </span>
                       </div>
                       <div className="text-lg font-bold text-slate-900">
-                        {new Date(
-                          analysisData.insights.peakDate,
-                        ).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        })}
+                        {(() => {
+                          const upcomingPeak = getUpcomingPeak(
+                            analysisData.predictions,
+                          );
+                          return new Date(
+                            upcomingPeak.peakDate,
+                          ).toLocaleDateString("en-US", {
+                            month: "short",
+                            day: "numeric",
+                          });
+                        })()}
                       </div>
                       <div className="text-xs text-slate-500">
-                        Best time to post content
+                        Predicted peak engagement
                       </div>
                     </div>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fusion-starter",
       "dependencies": {
         "express": "^4.18.2",
+        "react-is": "^19.1.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -6363,6 +6364,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
+    },
+    "node_modules/react-is": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
+      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
+      "license": "MIT"
     },
     "node_modules/react-reconciler": {
       "version": "0.27.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "react-hook-form": "^7.53.0",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
-        "recharts": "^2.12.7",
+        "recharts": "^3.0.2",
         "serverless-http": "^3.2.0",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
@@ -2640,6 +2640,33 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.8.2.tgz",
+      "integrity": "sha512-MYlOhQ0sLdw4ud48FoC5w0dH9VfWQjtCjreKwYTT3l+r427qYC5Y8PihNutepr8XrNaBUDQo9khWUwQxZaqt5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.19.2",
       "dev": true,
@@ -2927,6 +2954,20 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@swc/core": {
       "version": "1.11.24",
@@ -3508,21 +3549,29 @@
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3530,12 +3579,16 @@
       }
     },
     "node_modules/@types/d3-path": {
-      "version": "3.1.0",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
-      "version": "4.0.8",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3543,7 +3596,9 @@
       }
     },
     "node_modules/@types/d3-shape": {
-      "version": "3.1.6",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3551,12 +3606,16 @@
       }
     },
     "node_modules/@types/d3-time": {
-      "version": "3.0.3",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3718,6 +3777,13 @@
         "fflate": "~0.8.2",
         "meshoptimizer": "~0.18.1"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/webxr": {
       "version": "0.5.22",
@@ -4668,6 +4734,8 @@
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4679,6 +4747,8 @@
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4687,6 +4757,8 @@
     },
     "node_modules/d3-ease": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4695,6 +4767,8 @@
     },
     "node_modules/d3-format": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4703,6 +4777,8 @@
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4714,6 +4790,8 @@
     },
     "node_modules/d3-path": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4722,6 +4800,8 @@
     },
     "node_modules/d3-scale": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4737,6 +4817,8 @@
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4748,6 +4830,8 @@
     },
     "node_modules/d3-time": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4759,6 +4843,8 @@
     },
     "node_modules/d3-time-format": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4770,6 +4856,8 @@
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4805,6 +4893,8 @@
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4861,15 +4951,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
-      }
     },
     "node_modules/draco3d": {
       "version": "1.5.7",
@@ -4983,6 +5064,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.4",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.4.tgz",
@@ -5050,7 +5142,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "4.0.7",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5124,14 +5218,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/fast-equals": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/fdir": {
       "version": "6.4.4",
@@ -5429,6 +5515,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5446,6 +5543,8 @@
     },
     "node_modules/internmap": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5767,11 +5866,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lodash.castarray": {
       "version": "4.4.0",
@@ -6167,16 +6261,6 @@
         "lie": "^3.0.2"
       }
     },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -6280,11 +6364,6 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/react-reconciler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
@@ -6310,6 +6389,30 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-remove-scroll": {
@@ -6396,20 +6499,6 @@
         "react-dom": ">=16.8"
       }
     },
-    "node_modules/react-smooth": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-equals": "^5.0.1",
-        "prop-types": "^15.8.1",
-        "react-transition-group": "^4.4.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.1",
       "dev": true,
@@ -6432,21 +6521,6 @@
         }
       }
     },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
-      }
-    },
     "node_modules/react-use-measure": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
@@ -6463,33 +6537,48 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.12.7",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.0.2.tgz",
+      "integrity": "sha512-eDc3ile9qJU9Dp/EekSthQPhAVPG48/uM47jk+PF7VBQngxeW3cwQpPHb/GHC1uqwyCRWXcIrDzuHRVrnRryoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "clsx": "^2.0.0",
-        "eventemitter3": "^4.0.1",
-        "lodash": "^4.17.21",
-        "react-is": "^16.10.2",
-        "react-smooth": "^4.0.0",
-        "recharts-scale": "^0.4.4",
-        "tiny-invariant": "^1.3.1",
-        "victory-vendor": "^36.6.8"
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/recharts-scale": {
-      "version": "0.4.5",
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "decimal.js-light": "^2.4.1"
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/require-from-string": {
@@ -6501,6 +6590,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -7377,7 +7473,9 @@
       }
     },
     "node_modules/victory-vendor": {
-      "version": "36.9.2",
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
       "dev": true,
       "license": "MIT AND ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
+    "react-is": "^19.1.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "react-hook-form": "^7.53.0",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
-    "recharts": "^2.12.7",
+    "recharts": "^3.0.2",
     "serverless-http": "^3.2.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -318,11 +318,22 @@ function analyzeInsights(
     futureOutlook = "stable_niche";
   }
 
+  // Generate content creator recommendations
+  const track = data[0]; // Get track info from context if available
+  const creatorRecommendation = generateCreatorRecommendation(
+    currentTrend,
+    futureOutlook,
+    growthPotential,
+    momentum,
+    track?.genre,
+  );
+
   return {
     peakDate,
     peakListeners,
     currentTrend,
     futureOutlook,
+    creatorRecommendation,
   };
 }
 

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -479,28 +479,33 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
       );
     }
 
-    // Generate highly varied and realistic future predictions
+    // Generate data-driven future predictions based on historical patterns
     let predictions: TrendDataPoint[] = [];
 
-    // Create unique prediction characteristics based on song
-    const trackSeed = (track.title + track.artist).split("").reduce((a, b) => {
-      a = (a << 5) - a + b.charCodeAt(0);
-      return a & a;
-    }, 0);
-
-    const seededRandom = (seed: number) => {
-      const x = Math.sin(seed) * 10000;
-      return x - Math.floor(x);
-    };
-
-    // Get current baseline from historical data
+    // Analyze historical data trends
+    const recentDays = 14; // Analyze last 2 weeks
+    const recentData = historicalData.slice(-recentDays);
     const currentListeners =
       historicalData[historicalData.length - 1]?.infected ||
       parameters.initialInfected;
-    const historicalTrend = historicalData.slice(-7);
+
+    // Calculate trend metrics from actual data
+    const trendSlope =
+      recentData.length > 1
+        ? (recentData[recentData.length - 1].infected -
+            recentData[0].infected) /
+          recentData.length
+        : 0;
+
     const recentAverage =
-      historicalTrend.reduce((sum, point) => sum + point.infected, 0) /
-      historicalTrend.length;
+      recentData.reduce((sum, point) => sum + point.infected, 0) /
+      recentData.length;
+    const recentVolatility = calculateVolatility(recentData);
+    const weeklyPattern = calculateWeeklyPattern(historicalData);
+
+    // Determine natural trajectory based on actual data
+    const naturalGrowthRate = trendSlope / recentAverage; // percentage change per day
+    const momentumFactor = calculateMomentum(recentData);
 
     // Determine song-specific prediction characteristics
     const popularity = track.popularity / 100;

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -405,7 +405,6 @@ function analyzeInsights(
   }
 
   // Generate content creator recommendations
-  const track = data[0]; // Get track info from context if available
   const creatorRecommendation = generateCreatorRecommendation(
     currentTrend,
     futureOutlook,

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -242,6 +242,91 @@ function generateModelParameters(
   }
 }
 
+function generateCreatorRecommendation(
+  currentTrend: "rising" | "declining" | "stable",
+  futureOutlook: string,
+  growthPotential: number,
+  momentum: number,
+  genres?: string[],
+) {
+  let action: "use_now" | "wait_and_see" | "safe_choice" | "avoid";
+  let timing: "perfect" | "good" | "okay" | "poor";
+  let confidence: number;
+  let platforms: string[] = [];
+
+  // Determine optimal platforms based on genre
+  if (genres) {
+    if (
+      genres.includes("Pop") ||
+      genres.includes("Alternative") ||
+      genres.includes("Electronic")
+    ) {
+      platforms = ["TikTok", "Instagram Reels", "YouTube Shorts"];
+    } else if (genres.includes("Hip-Hop") || genres.includes("Rap")) {
+      platforms = ["TikTok", "YouTube", "Instagram"];
+    } else if (genres.includes("Rock") || genres.includes("Indie")) {
+      platforms = ["YouTube", "Instagram", "TikTok"];
+    } else if (genres.includes("R&B") || genres.includes("Soul")) {
+      platforms = ["Instagram", "TikTok", "YouTube"];
+    } else {
+      platforms = ["Instagram", "YouTube", "TikTok"];
+    }
+  } else {
+    platforms = ["TikTok", "Instagram", "YouTube"];
+  }
+
+  // Determine action and timing based on trends and outlook
+  if (
+    currentTrend === "rising" &&
+    (futureOutlook === "viral_potential" ||
+      futureOutlook === "explosive_growth")
+  ) {
+    action = "use_now";
+    timing = "perfect";
+    confidence = 90 + Math.floor(Math.random() * 10);
+  } else if (
+    currentTrend === "rising" &&
+    futureOutlook === "sustained_momentum"
+  ) {
+    action = "use_now";
+    timing = "perfect";
+    confidence = 85 + Math.floor(Math.random() * 10);
+  } else if (currentTrend === "stable" && growthPotential > 1.3) {
+    action = "use_now";
+    timing = "good";
+    confidence = 75 + Math.floor(Math.random() * 15);
+  } else if (
+    currentTrend === "declining" &&
+    futureOutlook === "comeback_likely"
+  ) {
+    action = "wait_and_see";
+    timing = "okay";
+    confidence = 60 + Math.floor(Math.random() * 20);
+  } else if (currentTrend === "stable" && futureOutlook === "stable_niche") {
+    action = "safe_choice";
+    timing = "good";
+    confidence = 70 + Math.floor(Math.random() * 15);
+  } else if (
+    currentTrend === "declining" &&
+    futureOutlook === "steady_decline"
+  ) {
+    action = "wait_and_see";
+    timing = "poor";
+    confidence = 40 + Math.floor(Math.random() * 20);
+  } else {
+    action = "safe_choice";
+    timing = "okay";
+    confidence = 65 + Math.floor(Math.random() * 20);
+  }
+
+  return {
+    action,
+    timing,
+    platforms,
+    confidence,
+  };
+}
+
 function analyzeInsights(
   data: TrendDataPoint[],
   predictions: TrendDataPoint[],

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -331,6 +331,7 @@ function analyzeInsights(
   data: TrendDataPoint[],
   predictions: TrendDataPoint[],
   modelType: "SIS" | "SEIR",
+  track?: MusicTrack,
 ) {
   const allData = [...data, ...predictions];
 

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -853,7 +853,12 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
     predictions = predictions.slice(1);
 
     // Analyze insights
-    const insights = analyzeInsights(historicalData, predictions, modelType);
+    const insights = analyzeInsights(
+      historicalData,
+      predictions,
+      modelType,
+      track,
+    );
 
     const response: TrendAnalysisResponse = {
       track,

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -605,19 +605,28 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
       } else {
         // SEIR model - follow historical trends for each compartment
         const lastHistorical = historicalData[historicalData.length - 1];
-        const prevHistorical = historicalData[historicalData.length - 2] || lastHistorical;
+        const prevHistorical =
+          historicalData[historicalData.length - 2] || lastHistorical;
 
         // Calculate historical trends for each compartment
-        const susceptibleTrend = (lastHistorical.susceptible - prevHistorical.susceptible) / Math.max(prevHistorical.susceptible, 1);
-        const exposedTrend = ((lastHistorical.exposed || 0) - (prevHistorical.exposed || 0)) / Math.max(prevHistorical.exposed || 1, 1);
-        const recoveredTrend = ((lastHistorical.recovered || 0) - (prevHistorical.recovered || 0)) / Math.max(prevHistorical.recovered || 1, 1);
+        const susceptibleTrend =
+          (lastHistorical.susceptible - prevHistorical.susceptible) /
+          Math.max(prevHistorical.susceptible, 1);
+        const exposedTrend =
+          ((lastHistorical.exposed || 0) - (prevHistorical.exposed || 0)) /
+          Math.max(prevHistorical.exposed || 1, 1);
+        const recoveredTrend =
+          ((lastHistorical.recovered || 0) - (prevHistorical.recovered || 0)) /
+          Math.max(prevHistorical.recovered || 1, 1);
 
         // Apply trends with natural decay
         const trendDecayFactor = Math.exp(-day * 0.1); // trends decay over time
 
         // Calculate exposed following its historical trend
         const baseExposed = lastHistorical.exposed || 0;
-        newExposed = Math.round(Math.max(0, baseExposed * (1 + exposedTrend * trendDecayFactor)));
+        newExposed = Math.round(
+          Math.max(0, baseExposed * (1 + exposedTrend * trendDecayFactor)),
+        );
 
         // Calculate recovered following proper SEIR logic
         const baseRecovered = lastHistorical.recovered || 0;
@@ -638,14 +647,22 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
 
         // Calculate susceptible to maintain population conservation
         // S + E + I + R = Total Population
-        newSusceptible = Math.round(parameters.totalPopulation - newExposed - newInfected - newRecovered);
+        newSusceptible = Math.round(
+          parameters.totalPopulation - newExposed - newInfected - newRecovered,
+        );
         newSusceptible = Math.max(0, newSusceptible); // Can't be negative
 
         // If susceptible would be too low, adjust recovered downward
-        if (newSusceptible < parameters.totalPopulation * 0.1) { // Minimum 10% susceptible
-          const adjustment = (parameters.totalPopulation * 0.1) - newSusceptible;
+        if (newSusceptible < parameters.totalPopulation * 0.1) {
+          // Minimum 10% susceptible
+          const adjustment = parameters.totalPopulation * 0.1 - newSusceptible;
           newRecovered = Math.max(0, newRecovered - adjustment);
-          newSusceptible = Math.round(parameters.totalPopulation - newExposed - newInfected - newRecovered);
+          newSusceptible = Math.round(
+            parameters.totalPopulation -
+              newExposed -
+              newInfected -
+              newRecovered,
+          );
         }
       }
 
@@ -679,7 +696,9 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
         const infectedDiff = smoothedInfected - originalInfected;
 
         if (modelType === "SIS") {
-          predictions[i].susceptible = Math.round(parameters.totalPopulation - smoothedInfected);
+          predictions[i].susceptible = Math.round(
+            parameters.totalPopulation - smoothedInfected,
+          );
         } else {
           // Adjust other compartments proportionally to maintain conservation
           const originalExposed = predictions[i].exposed || 0;
@@ -687,22 +706,19 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
 
           // If we reduced infected, add the difference to recovered (people lost interest)
           if (infectedDiff < 0) {
-            predictions[i].recovered = Math.round(originalRecovered + Math.abs(infectedDiff) * 0.7);
+            predictions[i].recovered = Math.round(
+              originalRecovered + Math.abs(infectedDiff) * 0.7,
+            );
             predictions[i].exposed = Math.round(originalExposed * 0.9); // slight reduction in exposed
           } else {
             // If we increased infected, it came from exposed
-            predictions[i].exposed = Math.round(Math.max(0, originalExposed - infectedDiff * 0.5));
+            predictions[i].exposed = Math.round(
+              Math.max(0, originalExposed - infectedDiff * 0.5),
+            );
             predictions[i].recovered = originalRecovered; // keep recovered same
           }
 
           // Recalculate susceptible to maintain total population
-          const totalAccounted = smoothedInfected + (predictions[i].exposed || 0) + (predictions[i].recovered || 0);
-          predictions[i].susceptible = Math.round(parameters.totalPopulation - totalAccounted);
-        }
-          predictions[i].recovered = Math.round(
-            smoothedInfected * recoveryRate * dayProgress,
-          );
-
           const totalAccounted =
             smoothedInfected +
             (predictions[i].exposed || 0) +

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -246,9 +246,11 @@ function generateModelParameters(
 function calculateVolatility(data: TrendDataPoint[]): number {
   if (data.length < 2) return 0;
 
-  const values = data.map(d => d.infected);
+  const values = data.map((d) => d.infected);
   const mean = values.reduce((sum, val) => sum + val, 0) / values.length;
-  const variance = values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / values.length;
+  const variance =
+    values.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) /
+    values.length;
 
   return Math.sqrt(variance) / mean; // coefficient of variation
 }
@@ -257,7 +259,7 @@ function calculateWeeklyPattern(data: TrendDataPoint[]): number[] {
   const weeklyAvg = Array(7).fill(0);
   const weeklyCounts = Array(7).fill(0);
 
-  data.forEach(point => {
+  data.forEach((point) => {
     const dayOfWeek = new Date(point.date).getDay();
     weeklyAvg[dayOfWeek] += point.infected;
     weeklyCounts[dayOfWeek]++;
@@ -269,7 +271,7 @@ function calculateWeeklyPattern(data: TrendDataPoint[]): number[] {
   }
 
   const overallAvg = weeklyAvg.reduce((sum, val) => sum + val, 0) / 7;
-  return weeklyAvg.map(val => val / overallAvg); // normalize to 1.0 average
+  return weeklyAvg.map((val) => val / overallAvg); // normalize to 1.0 average
 }
 
 function calculateMomentum(data: TrendDataPoint[]): number {
@@ -278,8 +280,10 @@ function calculateMomentum(data: TrendDataPoint[]): number {
   const firstHalf = data.slice(0, Math.floor(data.length / 2));
   const secondHalf = data.slice(Math.floor(data.length / 2));
 
-  const firstAvg = firstHalf.reduce((sum, p) => sum + p.infected, 0) / firstHalf.length;
-  const secondAvg = secondHalf.reduce((sum, p) => sum + p.infected, 0) / secondHalf.length;
+  const firstAvg =
+    firstHalf.reduce((sum, p) => sum + p.infected, 0) / firstHalf.length;
+  const secondAvg =
+    secondHalf.reduce((sum, p) => sum + p.infected, 0) / secondHalf.length;
 
   return secondAvg / firstAvg; // momentum factor
 }
@@ -289,7 +293,7 @@ function generateCreatorRecommendation(
   futureOutlook: string,
   growthPotential: number,
   momentum: number,
-  genres?: string[]
+  genres?: string[],
 ) {
   let action: "use_now" | "wait_and_see" | "safe_choice" | "avoid";
   let timing: "perfect" | "good" | "okay" | "poor";
@@ -527,14 +531,21 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
     // Analyze historical data trends
     const recentDays = 14; // Analyze last 2 weeks
     const recentData = historicalData.slice(-recentDays);
-    const currentListeners = historicalData[historicalData.length - 1]?.infected || parameters.initialInfected;
+    const currentListeners =
+      historicalData[historicalData.length - 1]?.infected ||
+      parameters.initialInfected;
 
     // Calculate trend metrics from actual data
-    const trendSlope = recentData.length > 1
-      ? (recentData[recentData.length - 1].infected - recentData[0].infected) / recentData.length
-      : 0;
+    const trendSlope =
+      recentData.length > 1
+        ? (recentData[recentData.length - 1].infected -
+            recentData[0].infected) /
+          recentData.length
+        : 0;
 
-    const recentAverage = recentData.reduce((sum, point) => sum + point.infected, 0) / recentData.length;
+    const recentAverage =
+      recentData.reduce((sum, point) => sum + point.infected, 0) /
+      recentData.length;
     const recentVolatility = calculateVolatility(recentData);
     const weeklyPattern = calculateWeeklyPattern(historicalData);
 
@@ -546,7 +557,9 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
     predictions = [];
 
     console.log(`Generating data-driven predictions for ${track.title}`);
-    console.log(`Current trend: slope=${trendSlope.toFixed(2)}, growth=${(naturalGrowthRate * 100).toFixed(2)}% per day`);
+    console.log(
+      `Current trend: slope=${trendSlope.toFixed(2)}, growth=${(naturalGrowthRate * 100).toFixed(2)}% per day`,
+    );
 
     for (let day = 1; day <= predictionDays; day++) {
       const futureDate = new Date(currentDate);
@@ -562,7 +575,8 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
       const weeklyMultiplier = weeklyPattern[dayOfWeek] || 1;
 
       // Add momentum effects
-      const momentumEffect = (momentumFactor - 1) * Math.exp(-dayProgress * 0.8);
+      const momentumEffect =
+        (momentumFactor - 1) * Math.exp(-dayProgress * 0.8);
 
       // Natural volatility based on historical data
       const noiseFactor = 1 + (Math.random() - 0.5) * recentVolatility * 0.5;
@@ -571,13 +585,15 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
       let baseInfected = currentListeners;
 
       // Apply trend effect
-      baseInfected *= (1 + currentTrendEffect * day);
+      baseInfected *= 1 + currentTrendEffect * day;
 
       // Apply momentum
-      baseInfected *= (1 + momentumEffect);
+      baseInfected *= 1 + momentumEffect;
 
       // Apply weekly pattern and noise
-      const newInfected = Math.round(baseInfected * weeklyMultiplier * noiseFactor);
+      const newInfected = Math.round(
+        baseInfected * weeklyMultiplier * noiseFactor,
+      );
 
       // Calculate other compartments based on model type
       let newSusceptible, newExposed, newRecovered;
@@ -591,7 +607,10 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
         const currentInfectedRatio = newInfected / parameters.totalPopulation;
 
         // Exposed: proportional to how viral the trend is
-        const exposureRate = Math.min(0.4, 0.1 + Math.abs(naturalGrowthRate) * 5);
+        const exposureRate = Math.min(
+          0.4,
+          0.1 + Math.abs(naturalGrowthRate) * 5,
+        );
         newExposed = Math.round(newInfected * exposureRate);
 
         // Recovered: grows over time but slower for trending content
@@ -600,7 +619,9 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
 
         // Susceptible: remaining population
         const totalAccounted = newInfected + newExposed + newRecovered;
-        newSusceptible = Math.round(parameters.totalPopulation - totalAccounted);
+        newSusceptible = Math.round(
+          parameters.totalPopulation - totalAccounted,
+        );
       }
 
       predictions.push({
@@ -613,67 +634,48 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
       });
     }
 
-        // Exposed population varies based on viral potential and current trends
-        const exposureRate =
-          0.2 + (popularity / 100) * 0.3 + (trendDirection > 0.9 ? 0.2 : 0);
-        newExposed = Math.round(
-          newInfected * exposureRate * (1 - dayProgress * 0.3),
-        );
-
-        // Recovered population grows more slowly for viral/trending content
-        const recoverySlowdown =
-          selectedScenario.includes("viral") ||
-          selectedScenario.includes("surge")
-            ? 0.7
-            : 1;
-        const baseRecovered = Math.round(
-          newInfected * (0.5 + dayProgress * 1.5) * recoverySlowdown,
-        );
-        newRecovered = Math.max(0, baseRecovered);
-
-        // Adjust susceptible population
-        const totalKnown = newInfected + (newExposed || 0) + newRecovered;
-        newSusceptible = Math.round(parameters.totalPopulation - totalKnown);
-      }
-
-      predictions.push({
-        date: futureDate.toISOString().split("T")[0],
-        susceptible: Math.max(0, newSusceptible),
-        exposed: newExposed,
-        infected: Math.max(1, newInfected),
-        recovered: newRecovered,
-        totalPopulation: parameters.totalPopulation,
-      });
-    }
-
-    // Enhanced smoothing that preserves intentional patterns while preventing unrealistic jumps
+    // Simple smoothing to prevent unrealistic day-to-day jumps
     for (let i = 1; i < predictions.length; i++) {
       const prev = predictions[i - 1].infected;
       const curr = predictions[i].infected;
 
-      // Dynamic max change based on current trend and scenario
-      let maxChangePercent = 0.25; // Base 25% max change
-
-      // Allow larger changes for viral scenarios
-      if (
-        selectedScenario.includes("viral") ||
-        selectedScenario.includes("surge")
-      ) {
-        maxChangePercent = 0.4; // 40% for viral content
-      } else if (
-        selectedScenario.includes("growth") ||
-        selectedScenario.includes("boost")
-      ) {
-        maxChangePercent = 0.3; // 30% for growth scenarios
-      }
-
+      // Limit to 20% max change per day based on data trends
+      const maxChangePercent = 0.2;
       const maxChange = prev * maxChangePercent;
 
-      // Only limit extremely unrealistic jumps
+      // Only smooth extreme jumps that don't match data patterns
       if (Math.abs(curr - prev) > maxChange) {
-        // Preserve direction but limit magnitude
         const direction = curr > prev ? 1 : -1;
         predictions[i].infected = Math.round(prev + maxChange * direction);
+
+        // Recalculate other compartments after smoothing
+        const smoothedInfected = predictions[i].infected;
+
+        if (modelType === "SIS") {
+          predictions[i].susceptible = Math.round(
+            parameters.totalPopulation - smoothedInfected,
+          );
+        } else {
+          const dayProgress = i / predictionDays;
+          const exposureRate = Math.min(
+            0.4,
+            0.1 + Math.abs(naturalGrowthRate) * 5,
+          );
+          const recoveryRate = naturalGrowthRate > 0 ? 0.3 : 0.6;
+
+          predictions[i].exposed = Math.round(smoothedInfected * exposureRate);
+          predictions[i].recovered = Math.round(
+            smoothedInfected * recoveryRate * dayProgress,
+          );
+
+          const totalAccounted =
+            smoothedInfected +
+            (predictions[i].exposed || 0) +
+            (predictions[i].recovered || 0);
+          predictions[i].susceptible = Math.round(
+            parameters.totalPopulation - totalAccounted,
+          );
+        }
       }
     }
 

--- a/server/routes/trend-analysis.ts
+++ b/server/routes/trend-analysis.ts
@@ -605,28 +605,19 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
       } else {
         // SEIR model - follow historical trends for each compartment
         const lastHistorical = historicalData[historicalData.length - 1];
-        const prevHistorical =
-          historicalData[historicalData.length - 2] || lastHistorical;
+        const prevHistorical = historicalData[historicalData.length - 2] || lastHistorical;
 
         // Calculate historical trends for each compartment
-        const susceptibleTrend =
-          (lastHistorical.susceptible - prevHistorical.susceptible) /
-          Math.max(prevHistorical.susceptible, 1);
-        const exposedTrend =
-          ((lastHistorical.exposed || 0) - (prevHistorical.exposed || 0)) /
-          Math.max(prevHistorical.exposed || 1, 1);
-        const recoveredTrend =
-          ((lastHistorical.recovered || 0) - (prevHistorical.recovered || 0)) /
-          Math.max(prevHistorical.recovered || 1, 1);
+        const susceptibleTrend = (lastHistorical.susceptible - prevHistorical.susceptible) / Math.max(prevHistorical.susceptible, 1);
+        const exposedTrend = ((lastHistorical.exposed || 0) - (prevHistorical.exposed || 0)) / Math.max(prevHistorical.exposed || 1, 1);
+        const recoveredTrend = ((lastHistorical.recovered || 0) - (prevHistorical.recovered || 0)) / Math.max(prevHistorical.recovered || 1, 1);
 
         // Apply trends with natural decay
         const trendDecayFactor = Math.exp(-day * 0.1); // trends decay over time
 
         // Calculate exposed following its historical trend
         const baseExposed = lastHistorical.exposed || 0;
-        newExposed = Math.round(
-          Math.max(0, baseExposed * (1 + exposedTrend * trendDecayFactor)),
-        );
+        newExposed = Math.round(Math.max(0, baseExposed * (1 + exposedTrend * trendDecayFactor)));
 
         // Calculate recovered following proper SEIR logic
         const baseRecovered = lastHistorical.recovered || 0;
@@ -647,22 +638,14 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
 
         // Calculate susceptible to maintain population conservation
         // S + E + I + R = Total Population
-        newSusceptible = Math.round(
-          parameters.totalPopulation - newExposed - newInfected - newRecovered,
-        );
+        newSusceptible = Math.round(parameters.totalPopulation - newExposed - newInfected - newRecovered);
         newSusceptible = Math.max(0, newSusceptible); // Can't be negative
 
         // If susceptible would be too low, adjust recovered downward
-        if (newSusceptible < parameters.totalPopulation * 0.1) {
-          // Minimum 10% susceptible
-          const adjustment = parameters.totalPopulation * 0.1 - newSusceptible;
+        if (newSusceptible < parameters.totalPopulation * 0.1) { // Minimum 10% susceptible
+          const adjustment = (parameters.totalPopulation * 0.1) - newSusceptible;
           newRecovered = Math.max(0, newRecovered - adjustment);
-          newSusceptible = Math.round(
-            parameters.totalPopulation -
-              newExposed -
-              newInfected -
-              newRecovered,
-          );
+          newSusceptible = Math.round(parameters.totalPopulation - newExposed - newInfected - newRecovered);
         }
       }
 
@@ -690,22 +673,32 @@ export const handleTrendAnalysis: RequestHandler = async (req, res) => {
         const direction = curr > prev ? 1 : -1;
         predictions[i].infected = Math.round(prev + maxChange * direction);
 
-        // Recalculate other compartments after smoothing
+        // Recalculate other compartments after smoothing to maintain SEIR flow
         const smoothedInfected = predictions[i].infected;
+        const originalInfected = curr;
+        const infectedDiff = smoothedInfected - originalInfected;
 
         if (modelType === "SIS") {
-          predictions[i].susceptible = Math.round(
-            parameters.totalPopulation - smoothedInfected,
-          );
+          predictions[i].susceptible = Math.round(parameters.totalPopulation - smoothedInfected);
         } else {
-          const dayProgress = i / predictionDays;
-          const exposureRate = Math.min(
-            0.4,
-            0.1 + Math.abs(naturalGrowthRate) * 5,
-          );
-          const recoveryRate = naturalGrowthRate > 0 ? 0.3 : 0.6;
+          // Adjust other compartments proportionally to maintain conservation
+          const originalExposed = predictions[i].exposed || 0;
+          const originalRecovered = predictions[i].recovered || 0;
 
-          predictions[i].exposed = Math.round(smoothedInfected * exposureRate);
+          // If we reduced infected, add the difference to recovered (people lost interest)
+          if (infectedDiff < 0) {
+            predictions[i].recovered = Math.round(originalRecovered + Math.abs(infectedDiff) * 0.7);
+            predictions[i].exposed = Math.round(originalExposed * 0.9); // slight reduction in exposed
+          } else {
+            // If we increased infected, it came from exposed
+            predictions[i].exposed = Math.round(Math.max(0, originalExposed - infectedDiff * 0.5));
+            predictions[i].recovered = originalRecovered; // keep recovered same
+          }
+
+          // Recalculate susceptible to maintain total population
+          const totalAccounted = smoothedInfected + (predictions[i].exposed || 0) + (predictions[i].recovered || 0);
+          predictions[i].susceptible = Math.round(parameters.totalPopulation - totalAccounted);
+        }
           predictions[i].recovered = Math.round(
             smoothedInfected * recoveryRate * dayProgress,
           );

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -74,6 +74,8 @@ export interface TrendAnalysisResponse {
       | "viral_potential"
       | "steady_decline"
       | "comeback_likely"
-      | "stable_niche";
+      | "stable_niche"
+      | "explosive_growth"
+      | "sustained_momentum";
   };
 }

--- a/shared/api.ts
+++ b/shared/api.ts
@@ -77,5 +77,11 @@ export interface TrendAnalysisResponse {
       | "stable_niche"
       | "explosive_growth"
       | "sustained_momentum";
+    creatorRecommendation: {
+      action: "use_now" | "wait_and_see" | "safe_choice" | "avoid";
+      timing: "perfect" | "good" | "okay" | "poor";
+      platforms: string[];
+      confidence: number;
+    };
   };
 }


### PR DESCRIPTION
Add futureOutlook prop to TrendChart component with six new outlook types:
- explosive_growth
- viral_potential  
- sustained_momentum
- comeback_likely
- stable_niche
- steady_decline

Implement getCreatorSignal() function that provides timing recommendations based on current trend and future outlook combinations.

Update chart display labels from music-focused to creator-focused terminology:
- "Current Listeners" → "Active Audience"
- "Peak Listeners" → "Viral Peak"
- "Market Potential" → "Total Reach"
- "Trend Status" → "Creator Signal"

Replace trend status display with creator signal showing action recommendation and reasoning.

Add getCreatorAdvice() helper function in Index.tsx for consistent creator recommendations across components.

Improve prediction algorithm with better momentum effects, weekly patterns, and SEIR compartment flow calculations.

Update API types to include new futureOutlook values and creatorRecommendation object structure.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/64fb2ce33f7246cbbca4604d51d272a6/zen-lab)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>64fb2ce33f7246cbbca4604d51d272a6</projectId>-->
<!--<branchName>zen-lab</branchName>-->